### PR TITLE
fix idiom

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ if docker_info := $(docker info --format '{{json .}}'):
 
 ## Three most frequent things that newcomers missed
 
-### 1. [Shell commands as known as subprocess commands](https://xon.sh/tutorial.html#python-mode-vs-subprocess-mode)
+### 1. [Shell commands also known as subprocess commands](https://xon.sh/tutorial.html#python-mode-vs-subprocess-mode)
 
 The first thing you should remember that the shell commands are not the calls of another shell (i.e. bash). The xonsh has it's own parser implementation for subprocess commands and this is the cause why the command like `echo {1..5} \;` (brace expansion and escape character in bash) is not working. Most of sh-shell features [can be replaced](https://xon.sh/bash_to_xsh.html) by the sane Python alternatives and the example before will be solved by `echo @(range(1,6)) ';'`. 
 


### PR DESCRIPTION
The English idiom for mentioning alternative names is "also known as", not "as known as". #1